### PR TITLE
Handle more kinds of definitions and build reorganization.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,17 +70,9 @@ lazy val cli = project
       "org.scalameta" %% "scalameta" % "1.8.0",
       "com.github.alexarchambault" %% "case-app" % "1.2.0-M3",
       "com.github.pathikrit" %% "better-files" % "3.0.0"
-    ),
-    javaOptions := Nil,
-    test.in(Test) :=
-      test.in(Test).dependsOn(compile.in(example, Compile)).value,
-    buildInfoPackage := "metadoc.tests",
-    buildInfoKeys := Seq[BuildInfoKey](
-      "exampleClassDirectory" -> classDirectory.in(example, Compile).value
     )
   )
   .dependsOn(coreJVM)
-  .enablePlugins(BuildInfoPlugin)
 
 lazy val js = project
   .in(file("metadoc-js"))
@@ -130,6 +122,21 @@ lazy val core = crossProject
   )
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
+
+lazy val tests = project
+  .in(file("metadoc-tests"))
+  .settings(
+    allSettings,
+    noPublish,
+    test.in(Test) :=
+      test.in(Test).dependsOn(compile.in(example, Compile)).value,
+    buildInfoPackage := "metadoc.tests",
+    buildInfoKeys := Seq[BuildInfoKey](
+      "exampleClassDirectory" -> classDirectory.in(example, Compile).value
+    )
+  )
+  .dependsOn(cli)
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val noPublish = Seq(
   publish := {},

--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,20 @@ lazy val core = crossProject
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
 
+commands += Command.command("metadoc-site") { s =>
+  val cliRun = Array(
+    "cli/run",
+    "--clean-target-first",
+    "--target",
+    "target/metadoc",
+    "example/target/scala-2.12/classes"
+  ).mkString(" ")
+
+  "example/compile" ::
+    cliRun ::
+    s
+}
+
 lazy val tests = project
   .in(file("metadoc-tests"))
   .settings(

--- a/example/src/main/scala/example/Example.scala
+++ b/example/src/main/scala/example/Example.scala
@@ -2,6 +2,10 @@ package example
 
 /** Docstring */
 object Example {
+  class Bar
+  case class Foo[T <: Bar](e: T)
+  def foo[T](e: T) = e
+  foo(new Foo[Bar](new Bar).copy(e = new Bar))
   val x = 2
   def main(args: Array[String]): Unit = {
     println(x)

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -1,16 +1,18 @@
-package metadoc.cli
+package metadoc.tests
 
 import java.nio.file.Files
 import caseapp.RemainingArgs
 import org.scalatest.FunSuite
 import better.files._
+import metadoc.cli.MetadocCli
+import metadoc.cli.MetadocOptions
 
 class MetadocCliTest extends FunSuite {
   test("Cli.main") {
     val out = Files.createTempDirectory("metadoc")
     out.toFile.toScala.deleteOnExit()
     val options = MetadocOptions(Some(out.toAbsolutePath.toString))
-    val files = metadoc.tests.BuildInfo.exampleClassDirectory.getAbsolutePath
+    val files = BuildInfo.exampleClassDirectory.getAbsolutePath
 
     // main()
     MetadocCli.run(options, RemainingArgs(List(files), Nil))


### PR DESCRIPTION
This PR 

1. adds support to classify type names and term parameters
as definitions. We also only persist d.Symbol files where the
definition is known.
2. move cli/test to tests/test
3. creates a metadoc-site command to generate the static site under target/metadoc.