### PR TITLE
Load editor content from the server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,11 +83,6 @@ lazy val js = project
     useYarn := true,
     emitSourceMaps := false, // Disabled to reduce warnings
     webpackConfigFile := Some(baseDirectory.value / "webpack.config.js"),
-    compileInputs.in(Compile, compile) :=
-      compileInputs
-        .in(Compile, compile)
-        .dependsOn(compile.in(example, Compile, compile))
-        .value,
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "scalameta" % "1.8.0",
       "org.scala-js" %%% "scalajs-dom" % "0.9.2"

--- a/metadoc-js/src/main/scala/scala/meta/internal/io/JSIO.scala
+++ b/metadoc-js/src/main/scala/scala/meta/internal/io/JSIO.scala
@@ -1,0 +1,27 @@
+package scala.meta.internal.io
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/*
+ * XXX: Ugly workaround to avoid 'Module not found' errors.
+ *
+ * Scalameta's Scala.js support depends on several Node.js modules which
+ * are not supported nor needed in the browser.
+ */
+
+@js.native
+@JSGlobal
+object JSShell extends js.Any
+
+@js.native
+@JSGlobal
+object JSFs extends js.Any
+
+@js.native
+@JSGlobal
+class JSStats extends js.Any
+
+@js.native
+@JSGlobal
+object JSPath extends js.Any

--- a/metadoc-js/webpack.config.js
+++ b/metadoc-js/webpack.config.js
@@ -80,5 +80,11 @@ module.exports = merge(config, {
         collapseWhitespace: true
       }
     })
-  ]
+  ],
+  devServer: {
+    contentBase: [
+      __dirname,
+      path.resolve(RootDir, '../target/metadoc')
+    ]
+  }
 });

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,6 @@ to build online code browser with "jump to definition" and "see usage". To run,
 git clone https://github.com/olafurpg/metadoc.git
 cd metadoc
 npm install -g yarn
-sbt js/fastOptJS::startWebpackDevServer
+sbt metadoc-site js/fastOptJS::startWebpackDevServer
 open http://localhost:8080
 ```


### PR DESCRIPTION
Change the frontend to read metadoc.index and load the content of the
first file listed via its semanticdb.