### PR TITLE
Fix read-only mode by defining IEditorConstructionOptions as a trait

### DIFF
--- a/metadoc-js/src/main/scala/metadoc/Metadoc.scala
+++ b/metadoc-js/src/main/scala/metadoc/Metadoc.scala
@@ -33,11 +33,11 @@ object MetadocApp extends js.JSApp {
     monaco.languages.setLanguageConfiguration(ScalaLanguageExtensionPoint.id, ScalaLanguage.conf)
     dom.document.getElementById("title").textContent = fileName
 
-    val editor = monaco.editor.create(app, MonacoEditor.IEditorConstructionOptions(
-      readOnly = true,
-      value = contents,
-      language = "scala"
-    ))
+    val editor = monaco.editor.create(app, new MonacoEditor.IEditorConstructionOptions {
+      override val readOnly = true
+      override val value = contents
+      override val language = "scala"
+    })
 
     dom.window.onresize = { _: dom.UIEvent => editor.layout() }
   }

--- a/metadoc-js/src/main/scala/metadoc/Monaco.scala
+++ b/metadoc-js/src/main/scala/metadoc/Monaco.scala
@@ -56,11 +56,12 @@ abstract class MonacoEditor extends js.Object {
 }
 
 object MonacoEditor {
-  case class IEditorConstructionOptions(
-    @(JSExport @field) value: js.UndefOr[String] = js.undefined,
-    @(JSExport @field) language: js.UndefOr[String] = js.undefined,
-    @(JSExport @field) readOnly: js.UndefOr[Boolean] = js.undefined
-  )
+  @ScalaJSDefined
+  trait IEditorConstructionOptions extends js.Object {
+    val value: js.UndefOr[String] = js.undefined
+    val language: js.UndefOr[String] = js.undefined
+    val readOnly: js.UndefOr[Boolean] = js.undefined
+  }
 
   case class IDimension(
     @(JSExport @field) height: Int,


### PR DESCRIPTION
It seems that the `@JSExport @field` combo doesn't work for as expected
for JavaScript objects used for passing options. For now use a trait so
the editor is read-only as expected.