### PR TITLE
Implement the DefinitionProvider

### DIFF
--- a/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
+++ b/metadoc-cli/src/main/scala/metadoc/cli/MetadocCli.scala
@@ -26,7 +26,6 @@ case class MetadocOptions(
 )
 
 case class MetadocSite(semanticdb: Seq[AbsolutePath],
-                       symbols: Seq[d.Symbol],
                        index: d.Index)
 
 object MetadocCli extends CaseApp[MetadocOptions] {
@@ -81,23 +80,11 @@ object MetadocCli extends CaseApp[MetadocOptions] {
       }
     }
 
-    def symbol(): Unit = {
-      val root = target.resolve("symbol")
-      root.toFile.mkdirs()
-      site.symbols.foreach { symbol =>
-        val out = root.resolve(URLEncoder.encode(symbol.symbol, "UTF-8"))
-        Files.createDirectories(out.toNIO.getParent)
-        Files.write(out.toNIO,
-                    symbol.toByteArray,
-                    StandardOpenOption.CREATE_NEW)
-      }
-    }
     def index(): Unit = {
       Files.write(target.resolve("metadoc.index").toNIO,
                   site.index.toByteArray)
     }
     semanticdb()
-    symbol()
     index()
   }
 
@@ -109,8 +96,8 @@ object MetadocCli extends CaseApp[MetadocOptions] {
     val files = db.entries.collect {
       case (Input.LabeledString(path, _), _) => path
     }
-    val index = d.Index(files, symbols.map(_.symbol))
-    val site = MetadocSite(classpath.shallow, symbols, index)
+    val index = d.Index(files, symbols)
+    val site = MetadocSite(classpath.shallow, index)
     createMetadocSite(site, options)
     println(options.target.get)
   }

--- a/metadoc-core/src/main/protobuf/metadoc.proto
+++ b/metadoc-core/src/main/protobuf/metadoc.proto
@@ -16,5 +16,5 @@ message Symbol {
 
 message Index {
     repeated string files = 1;
-    repeated string symbols = 2;
+    repeated Symbol symbols = 2;
 }

--- a/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
+++ b/metadoc-js/src/main/scala/metadoc/ScalaDefinitionProvider.scala
@@ -1,0 +1,45 @@
+package metadoc
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import org.scalajs.dom
+import scala.meta._
+import metadoc.schema.{Index, Symbol}
+
+@ScalaJSDefined
+class ScalaDefinitionProvider(attrs: Attributes, index: Index) extends MonacoLanguages.DefinitionProvider {
+  override def provideDefinition(
+    model: MonacoEditor.IReadOnlyModel,
+    position: Monaco.Position,
+    token: Monaco.CancellationToken): MonacoLanguages.Definition = {
+
+    val offset = model.getOffsetAt(position)
+
+    val symbol: Option[String] = attrs.names.collectFirst {
+      case (pos, sym) if pos.start.offset <= offset && offset <= pos.end.offset =>
+        sym.syntax
+    }
+    val maybeDefinition = symbol.flatMap { sym =>
+      index.symbols.collectFirst {
+        case Symbol(name, Some(definition), _) if sym == name =>
+          definition
+      }
+    }
+
+    maybeDefinition match {
+      case Some(definition) =>
+        val startPos = model.getPositionAt(definition.start)
+        val endPos = model.getPositionAt(definition.end)
+
+        // FIXME: check definition.filename and reload
+        MonacoLanguages.Location(
+          range = new Monaco.Range(
+            startPos.lineNumber, startPos.column,
+            endPos.lineNumber, endPos.column
+          ),
+          uri = model.uri)
+      case None =>
+        js.Array[MonacoLanguages.Location]()
+    }
+  }
+}

--- a/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
+++ b/metadoc-tests/src/test/scala/metadoc/tests/MetadocCliTest.scala
@@ -25,11 +25,5 @@ class MetadocCliTest extends FunSuite {
     assert(Files.exists(semanticdb))
     val semanticdbs = semanticdb.toFile.list()
     assert(semanticdbs.nonEmpty)
-
-    // symbol()
-    val symbol = out.resolve("symbol")
-    assert(Files.exists(symbol))
-    val symbols = symbol.toFile.list()
-    assert(symbols.nonEmpty)
   }
 }


### PR DESCRIPTION
Embed symbols inside the metadoc.index file to simplify lookup and use
the semantic DB and index data to implement a basic definition provider.

Still pretty rough but shows that we can implement the go-to part of the code navigation.
Live at https://jonas.github.io/metadoc/