### PR TITLE
Only register file actions once

### DIFF
--- a/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
+++ b/metadoc-js/src/main/scala/metadoc/MetadocEditorService.scala
@@ -6,6 +6,7 @@ import scala.scalajs.js
 import monaco.Range
 import monaco.Promise
 import monaco.Uri
+import monaco.editor.IActionDescriptor
 import monaco.editor.IEditor
 import monaco.editor.IEditorConstructionOptions
 import monaco.editor.IEditorOverrideServices
@@ -35,6 +36,9 @@ class MetadocEditorService(index: MetadocSemanticdbIndex)
 
     editor
   }
+
+  def addAction(action: IActionDescriptor): Unit =
+    editor.addAction(action)
 
   def resize(): Unit =
     editor.layout()

--- a/metadoc-js/src/main/scala/monaco/Monaco.scala
+++ b/metadoc-js/src/main/scala/monaco/Monaco.scala
@@ -1134,7 +1134,7 @@ package editor {
     var scrollTop: Double = js.native
   }
 
-//  @js.native
+  // @js.native - NOTE: Non-native to allow extending it in Scala
   trait IActionDescriptor extends js.Object {
     var id: String
     var label: String


### PR DESCRIPTION
... and unify history management in openEditor().

---
History works as I would expect with these changes.